### PR TITLE
Update `EnvSpec` to improve backward compatibility

### DIFF
--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -11,7 +11,7 @@ from gymnasium.utils import RecordConstructorArgs, seeding
 
 
 if TYPE_CHECKING:
-    from gymnasium.envs.registration import EnvSpec
+    from gymnasium.envs.registration import EnvSpec, WrapperSpec
 
 ObsType = TypeVar("ObsType")
 ActType = TypeVar("ActType")
@@ -266,6 +266,8 @@ class Wrapper(
         self._reward_range: tuple[SupportsFloat, SupportsFloat] | None = None
         self._metadata: dict[str, Any] | None = None
 
+        self._cached_spec: EnvSpec | None = None
+
     def __getattr__(self, name: str) -> Any:
         """Returns an attribute with ``name``, unless ``name`` starts with an underscore."""
         if name == "_np_random":
@@ -279,11 +281,11 @@ class Wrapper(
     @property
     def spec(self) -> EnvSpec | None:
         """Returns the :attr:`Env` :attr:`spec` attribute with the `WrapperSpec` if the wrapper inherits from `EzPickle`."""
+        if self._cached_spec is not None:
+            return self._cached_spec
+
         env_spec = self.env.spec
-
         if env_spec is not None:
-            from gymnasium.envs.registration import WrapperSpec
-
             # See if the wrapper inherits from `RecordConstructorArgs` then add the kwargs otherwise use `None` for the wrapper kwargs. This will raise an error in `make`
             if isinstance(self, RecordConstructorArgs):
                 kwargs = getattr(self, "_saved_kwargs")
@@ -293,6 +295,8 @@ class Wrapper(
             else:
                 kwargs = None
 
+            from gymnasium.envs.registration import WrapperSpec
+
             wrapper_spec = WrapperSpec(
                 name=self.class_name(),
                 entry_point=f"{self.__module__}:{type(self).__name__}",
@@ -301,9 +305,21 @@ class Wrapper(
 
             # to avoid reference issues we deepcopy the prior environments spec and add the new information
             env_spec = deepcopy(env_spec)
-            env_spec.applied_wrappers += (wrapper_spec,)
+            env_spec.additional_wrappers += (wrapper_spec,)
 
+        self._cached_spec = env_spec
         return env_spec
+
+    @classmethod
+    def wrapper_spec(cls, **kwargs: Any) -> WrapperSpec:
+        """Generates a `WrapperSpec` for the wrappers."""
+        from gymnasium.envs.registration import WrapperSpec
+
+        return WrapperSpec(
+            name=cls.class_name(),
+            entry_point=f"{cls.__module__}:{cls.__name__}",
+            kwargs=kwargs,
+        )
 
     @classmethod
     def class_name(cls) -> str:

--- a/gymnasium/wrappers/autoreset.py
+++ b/gymnasium/wrappers/autoreset.py
@@ -1,5 +1,14 @@
 """Wrapper that autoreset environments when `terminated=True` or `truncated=True`."""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
 import gymnasium as gym
+
+
+if TYPE_CHECKING:
+    from gymnasium.envs.registration import EnvSpec
 
 
 class AutoResetWrapper(gym.Wrapper, gym.utils.RecordConstructorArgs):
@@ -60,3 +69,17 @@ class AutoResetWrapper(gym.Wrapper, gym.utils.RecordConstructorArgs):
             info = new_info
 
         return obs, reward, terminated, truncated, info
+
+    @property
+    def spec(self) -> EnvSpec | None:
+        """Modifies the environment spec to specify the `autoreset=True`."""
+        if self._cached_spec is not None:
+            return self._cached_spec
+
+        env_spec = self.env.spec
+        if env_spec is not None:
+            env_spec = deepcopy(env_spec)
+            env_spec.autoreset = True
+
+        self._cached_spec = env_spec
+        return env_spec

--- a/gymnasium/wrappers/env_checker.py
+++ b/gymnasium/wrappers/env_checker.py
@@ -1,4 +1,9 @@
 """A passive environment checker wrapper for an environment's observation and action space along with the reset, step and render functions."""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
 import gymnasium as gym
 from gymnasium.core import ActType
 from gymnasium.utils.passive_env_checker import (
@@ -8,6 +13,10 @@ from gymnasium.utils.passive_env_checker import (
     env_reset_passive_checker,
     env_step_passive_checker,
 )
+
+
+if TYPE_CHECKING:
+    from gymnasium.envs.registration import EnvSpec
 
 
 class PassiveEnvChecker(gym.Wrapper, gym.utils.RecordConstructorArgs):
@@ -54,3 +63,17 @@ class PassiveEnvChecker(gym.Wrapper, gym.utils.RecordConstructorArgs):
             return env_render_passive_checker(self.env, *args, **kwargs)
         else:
             return self.env.render(*args, **kwargs)
+
+    @property
+    def spec(self) -> EnvSpec | None:
+        """Modifies the environment spec to such that `disable_env_checker=False`."""
+        if self._cached_spec is not None:
+            return self._cached_spec
+
+        env_spec = self.env.spec
+        if env_spec is not None:
+            env_spec = deepcopy(env_spec)
+            env_spec.disable_env_checker = False
+
+        self._cached_spec = env_spec
+        return env_spec

--- a/gymnasium/wrappers/order_enforcing.py
+++ b/gymnasium/wrappers/order_enforcing.py
@@ -1,6 +1,15 @@
 """Wrapper to enforce the proper ordering of environment operations."""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
 import gymnasium as gym
 from gymnasium.error import ResetNeeded
+
+
+if TYPE_CHECKING:
+    from gymnasium.envs.registration import EnvSpec
 
 
 class OrderEnforcing(gym.Wrapper, gym.utils.RecordConstructorArgs):
@@ -64,3 +73,17 @@ class OrderEnforcing(gym.Wrapper, gym.utils.RecordConstructorArgs):
     def has_reset(self):
         """Returns if the environment has been reset before."""
         return self._has_reset
+
+    @property
+    def spec(self) -> EnvSpec | None:
+        """Modifies the environment spec to add the `order_enforce=True`."""
+        if self._cached_spec is not None:
+            return self._cached_spec
+
+        env_spec = self.env.spec
+        if env_spec is not None:
+            env_spec = deepcopy(env_spec)
+            env_spec.order_enforce = True
+
+        self._cached_spec = env_spec
+        return env_spec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,14 +38,14 @@ dynamic = ["version"]
 # Update dependencies in `all` if any are added or removed
 atari = ["shimmy[atari] >=0.1.0,<1.0"]
 accept-rom-license = ["autorom[accept-rom-license] ~=0.4.2"]
-box2d = ["box2d-py ==2.3.5", "pygame ==2.1.3", "swig ==4.*"]
-classic-control = ["pygame ==2.1.3"]
-classic_control = ["pygame ==2.1.3"]  # kept for backward compatibility
+box2d = ["box2d-py ==2.3.5", "pygame ==2.1.3.dev8", "swig ==4.*"]
+classic-control = ["pygame ==2.1.3.dev8"]
+classic_control = ["pygame ==2.1.3.dev8"]  # kept for backward compatibility
 mujoco-py = ["mujoco-py >=2.1,<2.2"]
 mujoco_py = ["mujoco-py >=2.1,<2.2"]       # kept for backward compatibility
-mujoco = ["mujoco >=2.3.2", "imageio >=2.14.1"]
-toy-text = ["pygame ==2.1.3"]
-toy_text = ["pygame ==2.1.3"]         # kept for backward compatibility
+mujoco = ["mujoco >=2.3.1.post1", "imageio >=2.14.1"]
+toy-text = ["pygame ==2.1.3.dev8"]
+toy_text = ["pygame ==2.1.3.dev8"]         # kept for backward compatibility
 jax = ["jax ==0.3.24", "jaxlib ==0.3.24"]
 other = [
     "lz4 >=3.1.0",
@@ -61,17 +61,17 @@ all = [
     "shimmy[atari] >=0.1.0,<1.0",
     # box2d
     "box2d-py ==2.3.5",
-    "pygame ==2.1.3",
+    "pygame ==2.1.3.dev8",
     "swig ==4.*",
     # classic-control
-    "pygame ==2.1.3",
+    "pygame ==2.1.3.dev8",
     # mujoco-py
     "mujoco-py >=2.1,<2.2",
     # mujoco
-    "mujoco >=2.3.2",
+    "mujoco >=2.3.1.post1",
     "imageio >=2.14.1",
     # toy-text
-    "pygame ==2.1.3",
+    "pygame ==2.1.3.dev8",
     # jax
     "jax ==0.3.24",
     "jaxlib ==0.3.24",

--- a/tests/envs/registration/test_env_spec.py
+++ b/tests/envs/registration/test_env_spec.py
@@ -1,4 +1,4 @@
-"""Example file showing usage of env.specstack."""
+"""Test for the `EnvSpec`, in particular, a full integration with `EnvSpec`."""
 import pickle
 
 import pytest
@@ -11,15 +11,16 @@ from gymnasium.utils.env_checker import data_equivalence
 
 def test_full_integration():
     # Create an environment to test with
-    env = gym.make("CartPole-v1", render_mode="rgb_array").unwrapped
+    env = gym.make("CartPole-v1", render_mode="rgb_array")
 
-    env = gym.wrappers.FlattenObservation(env)
     env = gym.wrappers.TimeAwareObservation(env)
     env = gym.wrappers.NormalizeReward(env, gamma=0.8)
 
     # Generate the spec_stack
     env_spec = env.spec
     assert isinstance(env_spec, EnvSpec)
+    # additional_wrappers = (TimeAwareObservation, NormalizeReward)
+    assert len(env_spec.additional_wrappers) == 2
     # env_spec.pprint()
 
     # Serialize the spec_stack
@@ -30,10 +31,7 @@ def test_full_integration():
     recreate_env_spec = EnvSpec.from_json(env_spec_json)
     # recreate_env_spec.pprint()
 
-    for wrapper_spec, recreated_wrapper_spec in zip(
-        env_spec.applied_wrappers, recreate_env_spec.applied_wrappers
-    ):
-        assert wrapper_spec == recreated_wrapper_spec
+    assert env_spec.additional_wrappers == recreate_env_spec.additional_wrappers
     assert recreate_env_spec == env_spec
 
     # Recreate the environment using the spec_stack
@@ -86,43 +84,6 @@ def test_env_spec_to_from_json(env_spec: EnvSpec):
     assert env_spec == recreated_env_spec
 
 
-def test_wrapped_env_entry_point():
-    def _create_env():
-        _env = gym.make("CartPole-v1", render_mode="rgb_array")
-        _env = gym.wrappers.FlattenObservation(_env)
-        return _env
-
-    gym.register("TestingEnv-v0", entry_point=_create_env)
-
-    env = gym.make("TestingEnv-v0")
-    env = gym.wrappers.TimeAwareObservation(env)
-    env = gym.wrappers.NormalizeReward(env, gamma=0.8)
-
-    recreated_env = gym.make(env.spec)
-
-    obs, info = env.reset(seed=42)
-    recreated_obs, recreated_info = recreated_env.reset(seed=42)
-    assert data_equivalence(obs, recreated_obs)
-    assert data_equivalence(info, recreated_info)
-
-    action = env.action_space.sample()
-    obs, reward, terminated, truncated, info = env.step(action)
-    (
-        recreated_obs,
-        recreated_reward,
-        recreated_terminated,
-        recreated_truncated,
-        recreated_info,
-    ) = recreated_env.step(action)
-    assert data_equivalence(obs, recreated_obs)
-    assert data_equivalence(reward, recreated_reward)
-    assert data_equivalence(terminated, recreated_terminated)
-    assert data_equivalence(truncated, recreated_truncated)
-    assert data_equivalence(info, recreated_info)
-
-    del gym.registry["TestingEnv-v0"]
-
-
 def test_pickling_env_stack():
     env = gym.make("CartPole-v1", render_mode="rgb_array")
 
@@ -163,6 +124,8 @@ def test_pickling_env_stack():
 
 def test_env_spec_pprint():
     env = gym.make("CartPole-v1")
+    env = gym.wrappers.TimeAwareObservation(env)
+
     env_spec = env.spec
     assert env_spec is not None
 
@@ -172,10 +135,8 @@ def test_env_spec_pprint():
         == """id=CartPole-v1
 reward_threshold=475.0
 max_episode_steps=500
-applied_wrappers=[
-	name=PassiveEnvChecker, kwargs={},
-	name=OrderEnforcing, kwargs={'disable_render_order_enforcing': False},
-	name=TimeLimit, kwargs={'max_episode_steps': 500}
+additional_wrappers=[
+	name=TimeAwareObservation, kwargs={}
 ]"""
     )
 
@@ -186,10 +147,8 @@ applied_wrappers=[
 entry_point=gymnasium.envs.classic_control.cartpole:CartPoleEnv
 reward_threshold=475.0
 max_episode_steps=500
-applied_wrappers=[
-	name=PassiveEnvChecker, entry_point=gymnasium.wrappers.env_checker:PassiveEnvChecker, kwargs={},
-	name=OrderEnforcing, entry_point=gymnasium.wrappers.order_enforcing:OrderEnforcing, kwargs={'disable_render_order_enforcing': False},
-	name=TimeLimit, entry_point=gymnasium.wrappers.time_limit:TimeLimit, kwargs={'max_episode_steps': 500}
+additional_wrappers=[
+	name=TimeAwareObservation, entry_point=gymnasium.wrappers.time_aware_observation:TimeAwareObservation, kwargs={}
 ]"""
     )
 
@@ -205,14 +164,12 @@ order_enforce=True
 autoreset=False
 disable_env_checker=False
 applied_api_compatibility=False
-applied_wrappers=[
-	name=PassiveEnvChecker, kwargs={},
-	name=OrderEnforcing, kwargs={'disable_render_order_enforcing': False},
-	name=TimeLimit, kwargs={'max_episode_steps': 500}
+additional_wrappers=[
+	name=TimeAwareObservation, kwargs={}
 ]"""
     )
 
-    env_spec.applied_wrappers = ()
+    env_spec.additional_wrappers = ()
     output = env_spec.pprint(disable_print=True)
     assert (
         output
@@ -233,5 +190,5 @@ order_enforce=True
 autoreset=False
 disable_env_checker=False
 applied_api_compatibility=False
-applied_wrappers=[]"""
+additional_wrappers=[]"""
     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -171,7 +171,7 @@ def test_compatibility_with_old_style_env():
     """Test compatibility with old style environment."""
     env = OldStyleEnv()
     env = OrderEnforcing(env)
-    env = TimeLimit(env)
+    env = TimeLimit(env, 100)
     obs = env.reset()
     assert obs == 0
 

--- a/tests/wrappers/test_time_limit.py
+++ b/tests/wrappers/test_time_limit.py
@@ -7,7 +7,7 @@ from gymnasium.wrappers import TimeLimit
 
 def test_time_limit_reset_info():
     env = gym.make("CartPole-v1", disable_env_checker=True)
-    env = TimeLimit(env)
+    env = TimeLimit(env, 100)
     ob_space = env.observation_space
     obs, info = env.reset()
     assert ob_space.contains(obs)


### PR DESCRIPTION
Recreated from original PR: https://github.com/Farama-Foundation/Gymnasium/pull/355

# Description

As noted by https://github.com/DLR-RM/stable-baselines3/pull/1327#issuecomment-1445219678, there are significant backward compatibility issues with https://github.com/Farama-Foundation/Gymnasium/pull/292

This PR updates `EnvSpec` such that it is a "full description of the whole env". Using the `EnvSpec` in `make` is now identical to `make(str)` as before. Critically, the difference with `make` in v0.27 is that the `EnvSpec` changes with each wrapper applied, including the def...